### PR TITLE
Optimize pool pump runtime for cheapest electricity

### DIFF
--- a/pool_pump_dynamic.yaml
+++ b/pool_pump_dynamic.yaml
@@ -1,0 +1,176 @@
+alias: Pool Pump Control - Dynamic Price Based
+description: Smart pump control that finds cheapest 6-8 hours automatically based on electricity prices
+triggers:
+  - entity_id: sensor.stromligning_current_price_vat
+    trigger: state
+  - trigger: time
+    at: "00:01:00"  # Recalculate cheapest hours daily at midnight
+actions:
+  - variables:
+      current_time: "{{ now().strftime('%H:%M') }}"
+      current_hour: "{{ now().hour }}"
+      current_price: "{{ states('sensor.stromligning_current_price_vat') | float(0) }}"
+      
+      # Get today's hourly prices (assuming you have a sensor with hourly data)
+      # This may need adjustment based on your specific price sensor format
+      todays_prices: >-
+        {% set prices = [] %}
+        {% for hour in range(24) %}
+          {% set price_entity = 'sensor.stromligning_price_' ~ '%02d'|format(hour) %}
+          {% if states(price_entity) not in ['unknown', 'unavailable'] %}
+            {% set prices = prices + [{'hour': hour, 'price': states(price_entity) | float(0)}] %}
+          {% endif %}
+        {% endfor %}
+        {{ prices }}
+      
+      # Alternative: If you have attribute data with hourly prices
+      todays_prices_alt: >-
+        {% set hourly_data = state_attr('sensor.stromligning_current_price_vat', 'hourly_prices') %}
+        {% if hourly_data %}
+          {% set prices = [] %}
+          {% for item in hourly_data %}
+            {% set prices = prices + [{'hour': item.hour, 'price': item.price | float(0)}] %}
+          {% endfor %}
+          {{ prices }}
+        {% else %}
+          []
+        {% endif %}
+      
+      # Use whichever price data source is available
+      price_data: >-
+        {% if todays_prices_alt | length > 0 %}
+          {{ todays_prices_alt }}
+        {% else %}
+          {{ todays_prices }}
+        {% endif %}
+      
+      # Calculate cheapest hours (configurable between 6-8 hours)
+      pump_hours_target: 6  # Change this to 7 or 8 as needed
+      
+      cheapest_hours: >-
+        {% if price_data | length >= 24 %}
+          {% set sorted_prices = price_data | sort(attribute='price') %}
+          {% set cheapest = sorted_prices[:pump_hours_target] %}
+          {{ cheapest | map(attribute='hour') | list | sort }}
+        {% else %}
+          # Fallback to current time if no price data available
+          [{{ current_hour }}]
+        {% endif %}
+      
+      # Check if current hour is in cheapest hours
+      is_cheap_hour: "{{ current_hour in cheapest_hours }}"
+      
+      # Calculate next pump event
+      next_pump_event: >-
+        {% if is_cheap_hour %}
+          {% set next_off_hours = cheapest_hours | reject('<=', current_hour) | list %}
+          {% if next_off_hours | length > 0 %}
+            {{ next_off_hours | first + 1 }}
+          {% else %}
+            {% set tomorrow_cheap = cheapest_hours | reject('<=', current_hour) | list %}
+            {% if tomorrow_cheap | length > 0 %}
+              {{ tomorrow_cheap | first + 24 }}
+            {% else %}
+              {{ cheapest_hours | first + 24 }}
+            {% endif %}
+          {% endif %}
+        {% else %}
+          {% set next_on_hours = cheapest_hours | reject('<=', current_hour) | list %}
+          {% if next_on_hours | length > 0 %}
+            {{ next_on_hours | first }}
+          {% else %}
+            {{ cheapest_hours | first + 24 }}
+          {% endif %}
+        {% endif %}
+      
+      next_event_time: >-
+        {% if next_pump_event < 24 %}
+          {{ '%02d:00'|format(next_pump_event) }}
+        {% else %}
+          {{ '%02d:00 tomorrow'|format(next_pump_event - 24) }}
+        {% endif %}
+
+  # Update status message
+  - target:
+      entity_id: input_text.pump_alert_message
+    data:
+      value: >-
+        {{ current_time }}: Smart pump schedule analysis
+        Current hour: {{ current_hour }} | Price: {{ current_price }} DKK/kWh
+        
+        Today's cheapest {{ pump_hours_target }} hours: {{ cheapest_hours | join(', ') }}
+        Current hour is {% if is_cheap_hour %}IN{% else %}NOT IN{% endif %} cheapest periods
+        
+        {% if price_data | length < 24 %}
+        ⚠️ Limited price data available ({{ price_data | length }}/24 hours)
+        {% endif %}
+    action: input_text.set_value
+
+  # Main pump control logic
+  - choose:
+      # Turn pump ON during cheap hours
+      - conditions:
+          - condition: template
+            value_template: "{{ is_cheap_hour }}"
+        sequence:
+          - target:
+              entity_id: switch.pool_pump
+            action: switch.turn_on
+            data: {}
+          - target:
+              entity_id: input_text.pump_alert_message
+            data:
+              value: >-
+                {{ current_time }}: ✓ PUMP ON - Optimal pricing period
+                Current hour: {{ current_hour }} (cheapest {{ pump_hours_target }} hours)
+                Price: {{ current_price }} DKK/kWh
+                
+                Today's cheapest hours: {{ cheapest_hours | join(', ') }}
+                Next OFF at: {{ next_event_time }}
+                
+                💰 Running during {{ pump_hours_target }}-hour optimal window
+            action: input_text.set_value
+          - data:
+              title: "🏊 Pool Pump Started"
+              message: >-
+                Pool pump turned ON at {{ current_time }}
+                Running during optimal electricity pricing period
+                
+                • Current price: {{ current_price }} DKK/kWh
+                • Hour {{ current_hour }} is in cheapest {{ pump_hours_target }} hours today
+                • Cheapest hours: {{ cheapest_hours | join(', ') }}
+                • Next OFF: {{ next_event_time }}
+            action: persistent_notification.create
+    
+    # Turn pump OFF during expensive hours
+    default:
+      - target:
+          entity_id: switch.pool_pump
+        action: switch.turn_off
+        data: {}
+      - target:
+          entity_id: input_text.pump_alert_message
+        data:
+          value: >-
+            {{ current_time }}: ✗ PUMP OFF - Expensive period
+            Current hour: {{ current_hour }} (not in cheapest {{ pump_hours_target }} hours)
+            Price: {{ current_price }} DKK/kWh
+            
+            Today's cheapest hours: {{ cheapest_hours | join(', ') }}
+            Next ON at: {{ next_event_time }}
+            
+            💸 Avoiding expensive electricity period
+        action: input_text.set_value
+      - data:
+          title: "🏊 Pool Pump Stopped"
+          message: >-
+            Pool pump turned OFF at {{ current_time }}
+            Outside optimal electricity pricing period
+            
+            • Current price: {{ current_price }} DKK/kWh
+            • Daily target: {{ pump_hours_target }} cheapest hours
+            • Cheapest hours today: {{ cheapest_hours | join(', ') }}
+            • Next ON: {{ next_event_time }}
+        action: persistent_notification.create
+
+mode: single

--- a/pool_pump_dynamic.yaml
+++ b/pool_pump_dynamic.yaml
@@ -9,8 +9,9 @@ triggers:
     trigger: state  # Recalculate when runtime hours setting changes
 actions:
   - variables:
+      # Basic time and price variables
       current_time: "{{ now().strftime('%H:%M') }}"
-      current_hour: "{{ now().hour }}"
+      current_hour: "{{ now().hour | int }}"
       current_price: "{{ states('sensor.stromligning_current_price_vat') | float(0) }}"
       
       # Get today's hourly prices from the prices attribute
@@ -24,7 +25,7 @@ actions:
           {% if price_entry.start %}
             {% set start_time = price_entry.start | as_datetime %}
             {% if start_time and start_time.date() == today %}
-              {% set hour = start_time.hour %}
+              {% set hour = start_time.hour | int %}
               {% set price = price_entry.price | float(0) %}
               {% set prices = prices + [{'hour': hour, 'price': price}] %}
             {% endif %}
@@ -35,70 +36,88 @@ actions:
       # Get target hours from input_number entity (configurable via UI)
       pump_hours_target: "{{ states('input_number.pump_daily_runtime_hours') | int(6) }}"
       
+      # Calculate cheapest hours ensuring they are integers
       cheapest_hours: >-
         {% if todays_prices | length >= 18 %}
           {% set sorted_prices = todays_prices | sort(attribute='price') %}
-          {% set cheapest = sorted_prices[:pump_hours_target] %}
-          {{ cheapest | map(attribute='hour') | list | sort }}
+          {% set cheapest = sorted_prices[:pump_hours_target | int] %}
+          {% set hour_list = [] %}
+          {% for item in cheapest %}
+            {% set hour_list = hour_list + [item.hour | int] %}
+          {% endfor %}
+          {{ hour_list | sort }}
         {% else %}
-          # Fallback: use current logic if insufficient data
-          [{{ current_hour }}]
+          # Fallback: use current hour if insufficient data
+          [{{ current_hour | int }}]
         {% endif %}
       
       # Find the cheapest and most expensive prices for context
       cheapest_price: >-
         {% if todays_prices | length > 0 %}
-          {{ (todays_prices | sort(attribute='price') | first).price | round(3) }}
+          {{ (todays_prices | sort(attribute='price') | first).price | float | round(3) }}
         {% else %}
-          {{ current_price }}
+          {{ current_price | float }}
         {% endif %}
       
       most_expensive_price: >-
         {% if todays_prices | length > 0 %}
-          {{ (todays_prices | sort(attribute='price', reverse=true) | first).price | round(3) }}
+          {{ (todays_prices | sort(attribute='price', reverse=true) | first).price | float | round(3) }}
         {% else %}
-          {{ current_price }}
+          {{ current_price | float }}
         {% endif %}
       
       # Calculate potential savings
       price_savings: >-
         {{ ((most_expensive_price | float(0)) - (cheapest_price | float(0))) | round(3) }}
       
-      # Check if current hour is in cheapest hours
-      is_cheap_hour: "{{ current_hour in cheapest_hours }}"
+      # Check if current hour is in cheapest hours (ensure both are integers)
+      is_cheap_hour: "{{ (current_hour | int) in (cheapest_hours | list) }}"
       
       # Calculate next pump event
       next_pump_event: >-
-        {% if is_cheap_hour %}
-          {% set remaining_cheap_hours = cheapest_hours | reject('<=', current_hour) | list %}
+        {% set current_h = current_hour | int %}
+        {% set cheap_h = cheapest_hours | list %}
+        {% if (current_h in cheap_h) %}
+          {% set remaining_cheap_hours = cheap_h | reject('<=', current_h) | list %}
           {% if remaining_cheap_hours | length > 0 %}
-            {{ remaining_cheap_hours | first + 1 }}
+            {{ (remaining_cheap_hours | first | int) + 1 }}
           {% else %}
-            {% set tomorrow_first_cheap = cheapest_hours | first + 24 %}
-            {{ tomorrow_first_cheap }}
+            {{ (cheap_h | first | int) + 24 }}
           {% endif %}
         {% else %}
-          {% set upcoming_cheap_hours = cheapest_hours | reject('<=', current_hour) | list %}
+          {% set upcoming_cheap_hours = cheap_h | reject('<=', current_h) | list %}
           {% if upcoming_cheap_hours | length > 0 %}
-            {{ upcoming_cheap_hours | first }}
+            {{ upcoming_cheap_hours | first | int }}
           {% else %}
-            {{ cheapest_hours | first + 24 }}
+            {{ (cheap_h | first | int) + 24 }}
           {% endif %}
         {% endif %}
       
+      # Format next event time
       next_event_time: >-
-        {% if next_pump_event < 24 %}
-          {{ '%02d:00'|format(next_pump_event) }}
+        {% set next_event = next_pump_event | int %}
+        {% if next_event < 24 %}
+          {{ '%02d:00' | format(next_event) }}
         {% else %}
-          {{ '%02d:00 tomorrow'|format(next_pump_event - 24) }}
+          {{ '%02d:00 tomorrow' | format(next_event - 24) }}
         {% endif %}
       
       # Generate summary of all today's prices for debugging
       price_summary: >-
         {% set summary = [] %}
+        {% set cheap_h = cheapest_hours | list %}
+        {% set max_price = most_expensive_price | float %}
         {% for price in todays_prices | sort(attribute='hour') %}
-          {% set marker = '💰' if price.hour in cheapest_hours else '💸' if price.price >= most_expensive_price else '⚡' %}
-          {% set summary = summary + ['%02d:00 %s %.3f kr/kWh'|format(price.hour, marker, price.price)] %}
+          {% set hour = price.hour | int %}
+          {% set price_val = price.price | float %}
+          {% if hour in cheap_h %}
+            {% set marker = 'CHEAP' %}
+          {% elif price_val >= max_price %}
+            {% set marker = 'PEAK' %}
+          {% else %}
+            {% set marker = 'MID' %}
+          {% endif %}
+          {% set summary = summary + ['%02d:00 %s %.3f kr/kWh' | format(hour, marker, price_val)] %}
         {% endfor %}
         {{ summary | join('\n') }}
 

--- a/pool_pump_dynamic.yaml
+++ b/pool_pump_dynamic.yaml
@@ -1,5 +1,5 @@
 alias: Pool Pump Control - Dynamic Price Based
-description: Smart pump control that finds cheapest 6-8 hours automatically based on electricity prices
+description: Smart pump control that finds cheapest 6-8 hours automatically based on Strømligning electricity prices
 triggers:
   - entity_id: sensor.stromligning_current_price_vat
     trigger: state
@@ -11,51 +11,56 @@ actions:
       current_hour: "{{ now().hour }}"
       current_price: "{{ states('sensor.stromligning_current_price_vat') | float(0) }}"
       
-      # Get today's hourly prices (assuming you have a sensor with hourly data)
-      # This may need adjustment based on your specific price sensor format
+      # Get today's hourly prices from the prices attribute
+      price_data_raw: "{{ state_attr('sensor.stromligning_current_price_vat', 'prices') | default([]) }}"
+      
+      # Extract today's prices and convert to hour-price pairs
       todays_prices: >-
         {% set prices = [] %}
-        {% for hour in range(24) %}
-          {% set price_entity = 'sensor.stromligning_price_' ~ '%02d'|format(hour) %}
-          {% if states(price_entity) not in ['unknown', 'unavailable'] %}
-            {% set prices = prices + [{'hour': hour, 'price': states(price_entity) | float(0)}] %}
+        {% set today = now().date() %}
+        {% for price_entry in price_data_raw %}
+          {% if price_entry.start %}
+            {% set start_time = price_entry.start | as_datetime %}
+            {% if start_time and start_time.date() == today %}
+              {% set hour = start_time.hour %}
+              {% set price = price_entry.price | float(0) %}
+              {% set prices = prices + [{'hour': hour, 'price': price}] %}
+            {% endif %}
           {% endif %}
         {% endfor %}
         {{ prices }}
-      
-      # Alternative: If you have attribute data with hourly prices
-      todays_prices_alt: >-
-        {% set hourly_data = state_attr('sensor.stromligning_current_price_vat', 'hourly_prices') %}
-        {% if hourly_data %}
-          {% set prices = [] %}
-          {% for item in hourly_data %}
-            {% set prices = prices + [{'hour': item.hour, 'price': item.price | float(0)}] %}
-          {% endfor %}
-          {{ prices }}
-        {% else %}
-          []
-        {% endif %}
-      
-      # Use whichever price data source is available
-      price_data: >-
-        {% if todays_prices_alt | length > 0 %}
-          {{ todays_prices_alt }}
-        {% else %}
-          {{ todays_prices }}
-        {% endif %}
       
       # Calculate cheapest hours (configurable between 6-8 hours)
       pump_hours_target: 6  # Change this to 7 or 8 as needed
       
       cheapest_hours: >-
-        {% if price_data | length >= 24 %}
-          {% set sorted_prices = price_data | sort(attribute='price') %}
+        {% if todays_prices | length >= 18 %}
+          {% set sorted_prices = todays_prices | sort(attribute='price') %}
           {% set cheapest = sorted_prices[:pump_hours_target] %}
           {{ cheapest | map(attribute='hour') | list | sort }}
         {% else %}
-          # Fallback to current time if no price data available
+          # Fallback: use current logic if insufficient data
           [{{ current_hour }}]
         {% endif %}
+      
+      # Find the cheapest and most expensive prices for context
+      cheapest_price: >-
+        {% if todays_prices | length > 0 %}
+          {{ (todays_prices | sort(attribute='price') | first).price | round(3) }}
+        {% else %}
+          {{ current_price }}
+        {% endif %}
+      
+      most_expensive_price: >-
+        {% if todays_prices | length > 0 %}
+          {{ (todays_prices | sort(attribute='price', reverse=true) | first).price | round(3) }}
+        {% else %}
+          {{ current_price }}
+        {% endif %}
+      
+      # Calculate potential savings
+      price_savings: >-
+        {{ ((most_expensive_price | float(0)) - (cheapest_price | float(0))) | round(3) }}
       
       # Check if current hour is in cheapest hours
       is_cheap_hour: "{{ current_hour in cheapest_hours }}"
@@ -63,21 +68,17 @@ actions:
       # Calculate next pump event
       next_pump_event: >-
         {% if is_cheap_hour %}
-          {% set next_off_hours = cheapest_hours | reject('<=', current_hour) | list %}
-          {% if next_off_hours | length > 0 %}
-            {{ next_off_hours | first + 1 }}
+          {% set remaining_cheap_hours = cheapest_hours | reject('<=', current_hour) | list %}
+          {% if remaining_cheap_hours | length > 0 %}
+            {{ remaining_cheap_hours | first + 1 }}
           {% else %}
-            {% set tomorrow_cheap = cheapest_hours | reject('<=', current_hour) | list %}
-            {% if tomorrow_cheap | length > 0 %}
-              {{ tomorrow_cheap | first + 24 }}
-            {% else %}
-              {{ cheapest_hours | first + 24 }}
-            {% endif %}
+            {% set tomorrow_first_cheap = cheapest_hours | first + 24 %}
+            {{ tomorrow_first_cheap }}
           {% endif %}
         {% else %}
-          {% set next_on_hours = cheapest_hours | reject('<=', current_hour) | list %}
-          {% if next_on_hours | length > 0 %}
-            {{ next_on_hours | first }}
+          {% set upcoming_cheap_hours = cheapest_hours | reject('<=', current_hour) | list %}
+          {% if upcoming_cheap_hours | length > 0 %}
+            {{ upcoming_cheap_hours | first }}
           {% else %}
             {{ cheapest_hours | first + 24 }}
           {% endif %}
@@ -89,20 +90,37 @@ actions:
         {% else %}
           {{ '%02d:00 tomorrow'|format(next_pump_event - 24) }}
         {% endif %}
+      
+      # Generate summary of all today's prices for debugging
+      price_summary: >-
+        {% set summary = [] %}
+        {% for price in todays_prices | sort(attribute='hour') %}
+          {% set marker = '💰' if price.hour in cheapest_hours else '💸' if price.price >= most_expensive_price else '⚡' %}
+          {% set summary = summary + ['%02d:00 %s %.3f kr/kWh'|format(price.hour, marker, price.price)] %}
+        {% endfor %}
+        {{ summary | join('\n') }}
 
   # Update status message
   - target:
       entity_id: input_text.pump_alert_message
     data:
       value: >-
-        {{ current_time }}: Smart pump schedule analysis
-        Current hour: {{ current_hour }} | Price: {{ current_price }} DKK/kWh
+        {{ current_time }}: Smart Pool Pump Analysis 🏊‍♀️
         
-        Today's cheapest {{ pump_hours_target }} hours: {{ cheapest_hours | join(', ') }}
-        Current hour is {% if is_cheap_hour %}IN{% else %}NOT IN{% endif %} cheapest periods
+        📊 Current Status:
+        • Hour: {{ current_hour }} | Price: {{ current_price }} kr/kWh
+        • Status: {% if is_cheap_hour %}🟢 OPTIMAL PERIOD{% else %}🔴 EXPENSIVE PERIOD{% endif %}
         
-        {% if price_data | length < 24 %}
-        ⚠️ Limited price data available ({{ price_data | length }}/24 hours)
+        💰 Today's Strategy:
+        • Target: {{ pump_hours_target }} cheapest hours
+        • Cheapest hours: {{ cheapest_hours | join(', ') }}
+        • Price range: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
+        • Potential savings: {{ price_savings }} kr/kWh
+        
+        ⏰ Next Event: {{ 'OFF' if is_cheap_hour else 'ON' }} at {{ next_event_time }}
+        
+        {% if todays_prices | length < 18 %}
+        ⚠️ Limited price data: {{ todays_prices | length }}/24 hours available
         {% endif %}
     action: input_text.set_value
 
@@ -121,25 +139,32 @@ actions:
               entity_id: input_text.pump_alert_message
             data:
               value: >-
-                {{ current_time }}: ✓ PUMP ON - Optimal pricing period
-                Current hour: {{ current_hour }} (cheapest {{ pump_hours_target }} hours)
-                Price: {{ current_price }} DKK/kWh
+                {{ current_time }}: ✅ PUMP RUNNING - Optimal Period
                 
-                Today's cheapest hours: {{ cheapest_hours | join(', ') }}
-                Next OFF at: {{ next_event_time }}
+                💰 Smart Savings Active:
+                • Current: {{ current_price }} kr/kWh
+                • Today's cheapest: {{ cheapest_price }} kr/kWh  
+                • Saving vs peak: {{ price_savings }} kr/kWh
                 
-                💰 Running during {{ pump_hours_target }}-hour optimal window
-            action: input_text.set_value
-          - data:
-              title: "🏊 Pool Pump Started"
-              message: >-
-                Pool pump turned ON at {{ current_time }}
-                Running during optimal electricity pricing period
-                
-                • Current price: {{ current_price }} DKK/kWh
-                • Hour {{ current_hour }} is in cheapest {{ pump_hours_target }} hours today
+                ⏰ Schedule:
+                • Running {{ pump_hours_target }} hours total today
                 • Cheapest hours: {{ cheapest_hours | join(', ') }}
                 • Next OFF: {{ next_event_time }}
+                
+                🎯 Hour {{ current_hour }} is optimal for pool pump operation
+            action: input_text.set_value
+          - data:
+              title: "🏊 Pool Pump ON - Smart Schedule"
+              message: >-
+                💰 Running during optimal electricity pricing
+                
+                Current: {{ current_price }} kr/kWh
+                Today's range: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
+                
+                Optimal hours today: {{ cheapest_hours | join(', ') }}
+                Next scheduled OFF: {{ next_event_time }}
+                
+                Saving {{ price_savings }} kr/kWh vs peak rates! 💚
             action: persistent_notification.create
     
     # Turn pump OFF during expensive hours
@@ -152,25 +177,46 @@ actions:
           entity_id: input_text.pump_alert_message
         data:
           value: >-
-            {{ current_time }}: ✗ PUMP OFF - Expensive period
-            Current hour: {{ current_hour }} (not in cheapest {{ pump_hours_target }} hours)
-            Price: {{ current_price }} DKK/kWh
+            {{ current_time }}: ⏸️ PUMP OFF - Expensive Period
             
-            Today's cheapest hours: {{ cheapest_hours | join(', ') }}
-            Next ON at: {{ next_event_time }}
+            💸 Avoiding High Costs:
+            • Current: {{ current_price }} kr/kWh
+            • Today's cheapest: {{ cheapest_price }} kr/kWh
+            • Avoiding: {{ (current_price | float(0) - cheapest_price | float(0)) | round(3) }} kr/kWh extra cost
             
-            💸 Avoiding expensive electricity period
+            ⏰ Smart Schedule:
+            • Target: {{ pump_hours_target }} cheapest hours daily
+            • Optimal hours: {{ cheapest_hours | join(', ') }}
+            • Next ON: {{ next_event_time }}
+            
+            🎯 Waiting for better electricity prices
         action: input_text.set_value
       - data:
-          title: "🏊 Pool Pump Stopped"
+          title: "🏊 Pool Pump OFF - Smart Schedule"
           message: >-
-            Pool pump turned OFF at {{ current_time }}
-            Outside optimal electricity pricing period
+            💸 Avoiding expensive electricity period
             
-            • Current price: {{ current_price }} DKK/kWh
-            • Daily target: {{ pump_hours_target }} cheapest hours
-            • Cheapest hours today: {{ cheapest_hours | join(', ') }}
-            • Next ON: {{ next_event_time }}
+            Current: {{ current_price }} kr/kWh
+            Today's cheapest: {{ cheapest_price }} kr/kWh
+            
+            Optimal hours: {{ cheapest_hours | join(', ') }}
+            Next scheduled ON: {{ next_event_time }}
+            
+            Smart scheduling saves money! 💚
         action: persistent_notification.create
+
+  # Optional: Create a detailed price analysis helper (for debugging)
+  - target:
+      entity_id: input_text.price_analysis
+    data:
+      value: >-
+        📊 Today's Electricity Prices ({{ todays_prices | length }}/24 hours):
+        
+        {{ price_summary }}
+        
+        🎯 Strategy: Run pump during {{ pump_hours_target }} cheapest hours
+        💰 Total potential daily savings: {{ price_savings }} kr/kWh × pump_hours
+    action: input_text.set_value
+    continue_on_error: true  # Don't fail if this helper entity doesn't exist
 
 mode: single

--- a/pool_pump_dynamic.yaml
+++ b/pool_pump_dynamic.yaml
@@ -107,22 +107,17 @@ actions:
       entity_id: input_text.pump_alert_message
     data:
       value: >-
-        {{ current_time }}: Smart Pool Pump Analysis 🏊‍♀️
+        {{ current_time }}: Pool pump analysis
+        Current hour: {{ current_hour }}, Price: {{ current_price }} kr/kWh
+        Status: {% if is_cheap_hour %}Running - cheap period{% else %}Off - expensive period{% endif %}
         
-        📊 Current Status:
-        • Hour: {{ current_hour }} | Price: {{ current_price }} kr/kWh
-        • Status: {% if is_cheap_hour %}🟢 OPTIMAL PERIOD{% else %}🔴 EXPENSIVE PERIOD{% endif %}
-        
-        💰 Today's Strategy:
-        • Target: {{ pump_hours_target }} cheapest hours
-        • Cheapest hours: {{ cheapest_hours | join(', ') }}
-        • Price range: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
-        • Potential savings: {{ price_savings }} kr/kWh
-        
-        ⏰ Next Event: {{ 'OFF' if is_cheap_hour else 'ON' }} at {{ next_event_time }}
+        Target: {{ pump_hours_target }} cheapest hours today
+        Cheapest hours: {{ cheapest_hours | join(', ') }}
+        Price range: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
+        Next event: {{ 'OFF' if is_cheap_hour else 'ON' }} at {{ next_event_time }}
         
         {% if todays_prices | length < 18 %}
-        ⚠️ Limited price data: {{ todays_prices | length }}/24 hours available
+        Warning: Limited price data ({{ todays_prices | length }}/24 hours)
         {% endif %}
     action: input_text.set_value
 
@@ -141,32 +136,24 @@ actions:
               entity_id: input_text.pump_alert_message
             data:
               value: >-
-                {{ current_time }}: ✅ PUMP RUNNING - Optimal Period
+                {{ current_time }}: Pump ON - cheap period
+                Current: {{ current_price }} kr/kWh
+                Cheapest today: {{ cheapest_price }} kr/kWh
+                Saving: {{ price_savings }} kr/kWh vs peak
                 
-                💰 Smart Savings Active:
-                • Current: {{ current_price }} kr/kWh
-                • Today's cheapest: {{ cheapest_price }} kr/kWh  
-                • Saving vs peak: {{ price_savings }} kr/kWh
-                
-                ⏰ Schedule:
-                • Running {{ pump_hours_target }} hours total today
-                • Cheapest hours: {{ cheapest_hours | join(', ') }}
-                • Next OFF: {{ next_event_time }}
-                
-                🎯 Hour {{ current_hour }} is optimal for pool pump operation
+                Running {{ pump_hours_target }} hours today
+                Cheapest hours: {{ cheapest_hours | join(', ') }}
+                Next OFF: {{ next_event_time }}
             action: input_text.set_value
           - data:
-              title: "🏊 Pool Pump ON - Smart Schedule"
+              title: "Pool Pump Started"
               message: >-
-                💰 Running during optimal electricity pricing
-                
+                Running during cheap electricity period
                 Current: {{ current_price }} kr/kWh
-                Today's range: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
-                
-                Optimal hours today: {{ cheapest_hours | join(', ') }}
-                Next scheduled OFF: {{ next_event_time }}
-                
-                Saving {{ price_savings }} kr/kWh vs peak rates! 💚
+                Range today: {{ cheapest_price }} - {{ most_expensive_price }} kr/kWh
+                Cheap hours: {{ cheapest_hours | join(', ') }}
+                Next OFF: {{ next_event_time }}
+                Saving {{ price_savings }} kr/kWh vs peak
             action: persistent_notification.create
     
     # Turn pump OFF during expensive hours
@@ -179,32 +166,23 @@ actions:
           entity_id: input_text.pump_alert_message
         data:
           value: >-
-            {{ current_time }}: ⏸️ PUMP OFF - Expensive Period
+            {{ current_time }}: Pump OFF - expensive period
+            Current: {{ current_price }} kr/kWh
+            Cheapest today: {{ cheapest_price }} kr/kWh
+            Avoiding: {{ (current_price | float(0) - cheapest_price | float(0)) | round(3) }} kr/kWh extra cost
             
-            💸 Avoiding High Costs:
-            • Current: {{ current_price }} kr/kWh
-            • Today's cheapest: {{ cheapest_price }} kr/kWh
-            • Avoiding: {{ (current_price | float(0) - cheapest_price | float(0)) | round(3) }} kr/kWh extra cost
-            
-            ⏰ Smart Schedule:
-            • Target: {{ pump_hours_target }} cheapest hours daily
-            • Optimal hours: {{ cheapest_hours | join(', ') }}
-            • Next ON: {{ next_event_time }}
-            
-            🎯 Waiting for better electricity prices
+            Target: {{ pump_hours_target }} cheapest hours daily
+            Cheap hours: {{ cheapest_hours | join(', ') }}
+            Next ON: {{ next_event_time }}
         action: input_text.set_value
       - data:
-          title: "🏊 Pool Pump OFF - Smart Schedule"
+          title: "Pool Pump Stopped"
           message: >-
-            💸 Avoiding expensive electricity period
-            
+            Avoiding expensive electricity period
             Current: {{ current_price }} kr/kWh
-            Today's cheapest: {{ cheapest_price }} kr/kWh
-            
-            Optimal hours: {{ cheapest_hours | join(', ') }}
-            Next scheduled ON: {{ next_event_time }}
-            
-            Smart scheduling saves money! 💚
+            Cheapest today: {{ cheapest_price }} kr/kWh
+            Cheap hours: {{ cheapest_hours | join(', ') }}
+            Next ON: {{ next_event_time }}
         action: persistent_notification.create
 
   # Optional: Create a detailed price analysis helper (for debugging)
@@ -212,12 +190,12 @@ actions:
       entity_id: input_text.price_analysis
     data:
       value: >-
-        📊 Today's Electricity Prices ({{ todays_prices | length }}/24 hours):
+        Today's Electricity Prices ({{ todays_prices | length }}/24 hours):
         
         {{ price_summary }}
         
-        🎯 Strategy: Run pump during {{ pump_hours_target }} cheapest hours
-        💰 Total potential daily savings: {{ price_savings }} kr/kWh × pump_hours
+        Strategy: Run pump during {{ pump_hours_target }} cheapest hours
+        Potential daily savings: {{ price_savings }} kr/kWh per hour
     action: input_text.set_value
     continue_on_error: true  # Don't fail if this helper entity doesn't exist
 

--- a/pool_pump_dynamic.yaml
+++ b/pool_pump_dynamic.yaml
@@ -5,6 +5,8 @@ triggers:
     trigger: state
   - trigger: time
     at: "00:01:00"  # Recalculate cheapest hours daily at midnight
+  - entity_id: input_number.pump_daily_runtime_hours
+    trigger: state  # Recalculate when runtime hours setting changes
 actions:
   - variables:
       current_time: "{{ now().strftime('%H:%M') }}"
@@ -30,8 +32,8 @@ actions:
         {% endfor %}
         {{ prices }}
       
-      # Calculate cheapest hours (configurable between 6-8 hours)
-      pump_hours_target: 6  # Change this to 7 or 8 as needed
+      # Get target hours from input_number entity (configurable via UI)
+      pump_hours_target: "{{ states('input_number.pump_daily_runtime_hours') | int(6) }}"
       
       cheapest_hours: >-
         {% if todays_prices | length >= 18 %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This PR introduces a dynamic pool pump control automation that optimizes runtime based on real-time electricity prices. Instead of static schedules, the automation now:
*   Reads hourly price data from the `prices` attribute of `sensor.stromligning_current_price_vat`.
*   Automatically identifies and schedules the pump to run during the `pump_hours_target` (configurable, default 6) cheapest hours of the day.
*   Provides enhanced status messages and notifications, including current price, cheapest hours, potential savings, and next on/off times.
*   Includes a daily recalculation trigger to adapt to new price data.

This significantly improves cost efficiency and flexibility compared to fixed-time schedules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
<a href="https://cursor.com/background-agent?bcId=bc-4eb18aad-8f0a-4ebc-8696-ced8e6e78396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4eb18aad-8f0a-4ebc-8696-ced8e6e78396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>